### PR TITLE
First stab at adding propagation rules, split up execution in subcommands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(ctors-saving-refs ConstructorsSavingReferences.cc)
 target_link_libraries(ctors-saving-refs clangASTMatchers clangTooling)
 target_include_directories(ctors-saving-refs PRIVATE ${LLVM_INCLUDE_DIR})
 
-add_library(orca_tidy STATIC OrcaTidy.cc)
+add_library(orca_tidy STATIC OrcaTidy.cc IncludeFixer.cc IncludeFixer.h)
 target_include_directories(orca_tidy PUBLIC ${LLVM_INCLUDE_DIR})
 target_link_libraries(orca_tidy PUBLIC clangTooling)
 

--- a/IncludeFixer.cc
+++ b/IncludeFixer.cc
@@ -1,0 +1,56 @@
+#include "IncludeFixer.h"
+#include "clang/Format/Format.h"
+
+namespace format = clang::format;
+namespace tooling = clang::tooling;
+
+static tooling::Replacements CreateHeaderInsertionForFile(
+    llvm::StringRef source_path) {
+  return tooling::Replacements{
+      {source_path, UINT_MAX, 0, "#include \"gpos/common/owner.h\""}};
+}
+
+namespace orca_tidy {
+bool IncludeFixer::BeginSourceFileAction(clang::CompilerInstance& CI) {
+  auto source_path = getCurrentFile();
+  tooling::Replacements insertion = CreateHeaderInsertionForFile(source_path);
+  auto buffer = llvm::MemoryBuffer::getFile(source_path);
+  if (!buffer) {
+    llvm::errs() << "Couldn't open file: " + source_path + ": "
+                 << buffer.getError().message() + '\n';
+    return false;
+  }
+  llvm::StringRef code = buffer.get()->getBuffer();
+  auto style = format::getStyle(format::DefaultFormatStyle, source_path,
+                                format::DefaultFallbackStyle);
+  if (!style) {
+    llvm::errs() << llvm::toString(style.takeError()) << '\n';
+    return false;
+  }
+  auto clean_replaces =
+      format::cleanupAroundReplacements(code, insertion, *style);
+
+  if (!clean_replaces) {
+    llvm::errs() << llvm::toString(clean_replaces.takeError()) << '\n';
+    return false;
+  }
+
+  insertion = std::move(clean_replaces.get());
+
+  file_to_replaces.emplace(source_path, std::move(insertion));
+
+  return true;
+}
+IncludeFixer::IncludeFixer(
+    std::map<std::string, tooling::Replacements>& file_to_replaces)
+    : file_to_replaces(file_to_replaces) {}
+
+std::unique_ptr<clang::FrontendAction> IncludeFixerActionFactory::create() {
+  return std::unique_ptr<clang::FrontendAction>(
+      new IncludeFixer(file_to_replaces));
+}
+
+IncludeFixerActionFactory::IncludeFixerActionFactory(
+    std::map<std::string, clang::tooling::Replacements>& file_to_replaces)
+    : file_to_replaces(file_to_replaces) {}
+}  // namespace orca_tidy

--- a/IncludeFixer.h
+++ b/IncludeFixer.h
@@ -1,0 +1,32 @@
+#ifndef ORCATIDY__INCLUDEFIXER_H_
+#define ORCATIDY__INCLUDEFIXER_H_
+#include <map>
+#include <string>
+#include <vector>
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/Tooling/Core/Replacement.h"
+#include "clang/Tooling/Tooling.h"
+
+namespace orca_tidy {
+struct IncludeFixer : clang::PreprocessorFrontendAction {
+  std::map<std::string, clang::tooling::Replacements> &file_to_replaces;
+
+ protected:
+ public:
+  explicit IncludeFixer(
+      std::map<std::string, clang::tooling::Replacements> &file_to_replaces);
+
+ protected:
+  bool BeginSourceFileAction(clang::CompilerInstance &CI) override;
+  void ExecuteAction() override {}
+};
+
+struct IncludeFixerActionFactory : clang::tooling::FrontendActionFactory {
+  std::map<std::string, clang::tooling::Replacements> &file_to_replaces;
+
+  explicit IncludeFixerActionFactory(
+      std::map<std::string, clang::tooling::Replacements> &file_to_replaces);
+  std::unique_ptr<clang::FrontendAction> create() override;
+};
+}  // namespace orca_tidy
+#endif  // ORCATIDY__INCLUDEFIXER_H_

--- a/OrcaTidy.cc
+++ b/OrcaTidy.cc
@@ -162,7 +162,9 @@ struct Annotator {
     for (const auto& bound_nodes : match(
              functionDecl(
                  hasDescendant(returnStmt(hasReturnValue(ignoringParenImpCasts(
-                     declRefExpr(to(varDecl(hasType(OwnerType())))))))),
+                     anyOf(declRefExpr(to(varDecl(hasType(OwnerType())))),
+                           callExpr(
+                               callee(functionDecl(returns(OwnerType()))))))))),
                  returns(ref_count_pointer_type))
                  .bind("f"),
              ast_context)) {

--- a/OrcaTidy.h
+++ b/OrcaTidy.h
@@ -6,15 +6,23 @@
 #include "clang/Tooling/Refactoring.h"
 
 namespace orca_tidy {
+
+struct ActionOptions {
+  bool Base = true;
+  bool Propagate = true;
+};
+
 class AnnotateAction {
  public:
   explicit AnnotateAction(
-      std::map<std::string, clang::tooling::Replacements>& replacements)
-      : replacements_(replacements) {}
+      std::map<std::string, clang::tooling::Replacements>& replacements,
+      ActionOptions action_options)
+      : replacements_(replacements), action_options_(action_options) {}
   std::unique_ptr<clang::ASTConsumer> newASTConsumer();
 
  private:
   std::map<std::string, clang::tooling::Replacements>& replacements_;
+  ActionOptions action_options_;
 };
 }  // namespace orca_tidy
 #endif  // ORCATIDY__ORCATIDY_H_

--- a/OrcaTidyMain.cc
+++ b/OrcaTidyMain.cc
@@ -81,11 +81,10 @@ int main(int argc, const char* argv[]) {
     // Export replacements.
     tooling::TranslationUnitReplacements tur;
     const auto& file_to_replacements = tool.getReplacements();
-    for (const auto& entry : file_to_replacements) {
-      auto file = entry.first;
-      const tooling::Replacements& unclean_replacements = entry.second;
+    for (const auto& [file, unclean_replacements] : file_to_replacements) {
       tur.Replacements.insert(tur.Replacements.end(),
-                              unclean_replacements.begin(), entry.second.end());
+                              unclean_replacements.begin(),
+                              unclean_replacements.end());
     }
 
     llvm::yaml::Output yaml(os);


### PR DESCRIPTION
This patch set adds the initial propagation rules:

1. A function returning an owner variable returns an owner
2. A function returning a call to another owner-returning function returns an owner

While working on the above, it becomes clear that propagation rules are different from base rules in that:

1. They are intended to be run repeatedly until we reach a fixed point
2. Header insertion using `clang-include-fixer` has become a significant bottleneck while looping. For context, a single sweep over all changed files by `clang-include-fixer` takes at least 4 minutes on my laptop (with a 4 GHz mobile Xeon).

To better facilitate running propagation rules, the following enhancements are made:

1. Add a new functionality of include fixing. This leverages existing API in libFormat and its blazing fast: 2.5 seconds for the same set of files compared to 4 minutes mentioned above. The results are not byte-wise identical to `clang-include-fixer` as this tool is purely based on a lower-level API (lexer and preprocessor) without going through the parser / semantic analysis, and hence it cannot do the fancy namespace qualifier addition / removal that `clang-include-fixer` does. However, given that the goal of the annotations is to be ephemeral and erased eventually, this is acceptable.
2. Break the functionalities into 3 subcommands:
   1. `base`
   2. `propagate`
   3. `fix-include`

